### PR TITLE
Fix Readme Anchor Link for Components and Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - [Presentations](https://github.com/nikgraf/awesome-react-vr#presentations)
 - [Blog Posts & Articles](https://github.com/nikgraf/awesome-react-vr#blog-posts--articles)
-- [Components](https://github.com/nikgraf/awesome-react-vr#components)
+- [Components](https://github.com/nikgraf/awesome-react-vr#frameworks-and-components)
 - [License](https://github.com/nikgraf/awesome-react-vr#license)
 
 ## Presentations


### PR DESCRIPTION
It seems this link wasn't updated when the h2 text was changed a bunch of months back. Thought I'd just fix it.